### PR TITLE
Enable reading and writing to s3

### DIFF
--- a/data_processing/models/ahrq.gov/sdoh/sdoh_county.sql
+++ b/data_processing/models/ahrq.gov/sdoh/sdoh_county.sql
@@ -1,6 +1,6 @@
 {{ config(
         materialized = 'external',
-        location = '../data/sdoh_county.parquet'
+        location = 's3://payless.health/sdoh_county.parquet'
     )
 }}
 

--- a/data_processing/profiles.yml
+++ b/data_processing/profiles.yml
@@ -4,6 +4,12 @@ healthcare_data:
   outputs:
     dev:
       type: duckdb
-      threads: 1
+      threads: 3
+      temp_directory: '/.tmp'
       plugins:
         - module: excel
+      extensions:
+        - httpfs
+        - parquet
+        - aws
+      use_credential_provider: aws


### PR DESCRIPTION
I'm adding config settings to `profiles.yml` to enable dbt-duckdb to read from and write to an authenticated s3 bucket.

To make use of this, I configured my environment using `aws configure sso` and my onefact.org AWS credentials. Once the session is authenticated, dbt will use those credentials (via the `use_credential_provider` setting) and the `location` parameter in the model to define where the output file gets materialized (like in `sdoh_county.sql`).

Then selecting that command in dbt will produce the parquet file in s3 rather than locally.

`dbt run --select sdoh_county`

I can write up some documentation and point to other resources that I used to get this working if it would be helpful for others.